### PR TITLE
Updates to Emacs-for-live

### DIFF
--- a/editor-integration/emacs-for-live.org
+++ b/editor-integration/emacs-for-live.org
@@ -7,9 +7,15 @@ Make sure you install osc.el
 
 This is done up org-mode style.  For now just do ~(org-babel-load-file /this-file/)~ and it will set everything up.  A proper elisp file is on the todo list.
 
+You can bootstrap this file by moving the point into this code block and hitting C-c C-c
 #+begin_src emacs-lisp :tangle no
+(use-package osc)
 (org-babel-load-file "emacs-for-live.org")
 #+end_src
+
+
+#+RESULTS:
+: Loaded emacs-for-live.el
 
 
 * Notes
@@ -22,8 +28,6 @@ This is done up org-mode style.  For now just do ~(org-babel-load-file /this-fil
 
 * Code
 
-(org-babel-load-file  "./emacs-for-live.org")
-  
 ** Setting up network connections
 
 *** Client
@@ -39,9 +43,11 @@ I am not sure why yet. My current bullshit theory is that the UDP connections wo
  
 (defvar e4l-osc-client nil "Connection to send OSC From Emacs")
 
+(defvar e4l-osc-clientport 7723 "Port to connect to")
+
 (defun e4l-osc-connect ()
   (when e4l-osc-client (delete-process e4l-osc-client))
-  (setq e4l-osc-client (osc-make-client "127.0.0.1" 7723))
+  (setq e4l-osc-client (osc-make-client "127.0.0.1" e4l-osc-clientport))
   e4l-osc-client)
 #+end_src
 
@@ -96,33 +102,38 @@ Just a real slim one for now.  It'd be nice to have a full bidirectional Geiser 
 
 Next up we need a listening UDP server.  Note that the server code is familiar to the client code.  That's strike 2.  3 strikes and it should be refactored!
 
-#+begin_src emacs-lisp 
-(defvar e4l-osc-server nil)
+Note that right now we just cheerfully assume a single client and a single server process. This may not be smart.
 
+#+begin_src emacs-lisp 
 (defun e4l-server-start ()
   "Starts the listening server"
   (when e4l-osc-server (delete-process e4l-osc-server))
   (setq e4l-osc-server (osc-make-server "127.0.0.1" 7724 'e4l-echo-handler)))
 
-(e4l-server-start)
-
 (defun e4l-echo-handler (path &rest args)
   "Basic handler just outputs whatever came into it into the message buffer"
   (message "E4L: [path: %s] %S" path args))
+
+(defvar e4l-osc-server (e4l-server-start))
+
 #+end_src
 
 Now, lets make an attach function that verifies the bidirectional communication.  We use the same name as most other emacs functions.  In the future this could be a real REPL, but... baby steps!
 
 *** TODO set up tangling so we can just dump the scheme code with <<<HEREDOC>>>
 
-#+begin_src emacs-lisp 
+#+begin_src emacs-lisp :tangle yes
 (defun run-e4l ()
   "Set up s4l to be bidirectional and send a test message"
+  (interactive)
   (e4l-server-start)
   (e4l-eval "(define (send-to-e4l path . result) (apply send (append (list 'udp-send path) result)))")
   (e4l-eval "(post 'prepping-to-send)")
   (e4l-eval "(send-to-e4l '/test \"BidiCon Established!\"))"))
 #+end_src
+
+#+RESULTS:
+: run-e4l
 
 So now you can get results back from e4l via this bidirectional...thing.  Boy howdy wouldn't it be cool if the console just output those messages?
 
@@ -133,6 +144,10 @@ Well...
 #+end_src
 
 
+#+RESULTS:
+
+
+#+name: send-console-to-emacs
 #+begin_src scheme
 (define (s4m-filter-result result)
   (let ((converted (object->string result)))
@@ -142,7 +157,7 @@ Well...
 
 Did it work?
 
-#+begin_src emacs-lisp 
+#+begin_src emacs-lisp :tangle no
 (e4l-eval "(post 'test)")
 #+end_src
 
@@ -150,6 +165,8 @@ YEEESSS.
 
 * Emacs for Live
 
+  Note that this section needs to be executed manually within the s4m context.
+  
   We'll need a ~live.object~ connected to the s4m object.  For now it goes in inlet2 and it's varname is ~live-object~.
 
   We also have a ~live.path~ in going in inlet 2 of the ~live.object~ with the script name ~live-path~.
@@ -157,14 +174,67 @@ YEEESSS.
   Here is a bit of basic peeking at the live environment:
   
 #+begin_src scheme 
-(send 'live-path 'path 'live_app)
-
-(define (e4l-info-handler args) 
-  (send-to-e4l '/live-object (object->string args)))
+(define (e4l-info-handler args)
+  (post (object->string args))
+  (cond
+   ((equal? (cadr args) 'description)
+    (send-to-e4l '/live-object
+                 (list 'description
+                       (string-append ""
+                                      (map (lambda (arg) (string-append (object->string arg) " ")))
+                                      "")
+                       (cddr args))))
+   (else 
+    (send-to-e4l '/live-object (object->string args)))))
 
 (listen 1 'info e4l-info-handler)
 
+(define (e4l-id? kons)
+  (and (pair? kons)
+       (equal? (car kons) 'id)))
+
+(define (e4l-current? kons)
+  (or (equal? 'current kons)
+      (null? kons)
+      (and (pair? kons)
+           (equal? 'current (car kons)))))
+
+(define (e4l-set-id path-or-id)
+  (cond
+   ((e4l-id? path-or-id)
+    (apply send (concat '(live-object) path-or-id)))
+   ((e4l-current? path-or-id))
+   (else 
+    (apply send (concat '(live-path path) path-or-id)))))
+
+(define (e4l-get-info . path)
+  (e4l-set-id path)
+  (send 'live-object 'getinfo))
+
+(define (e4l-prop-handler args)
+  (send-to-e4l '/live-prop (object->string args)))
+
+(define (e4l-get-prop path-or-id prop)
+  (e4l-set-id path-or-id)
+  (listen 1 prop e4l-prop-handler)
+  (send 'live-object 'get prop))
+
+(apply send (concat '(live-object id) 56))
 (send 'live-object 'getinfo)
+
+(e4l-set-id '(live_set))
+(e4l-set-id '(id 33))
+
+(e4l-current? '())
+
+(e4l-get-info 'current)
+(e4l-get-info)
+(e4l-get-info '(id 33))
+(e4l-get-info 'live_set)
+
+(e4l-get-prop '(live_set) 'scale_name)
+(e4l-get-prop '(live_set) 'scale_intervals)
+(e4l-get-prop '(live_set) 'master_track)
 #+end_src
 
 This:
@@ -202,6 +272,8 @@ E4L: [path: /live-object] ("(done)")
    The main object handler will set up a buffer called ~*e4l-object*~, and then each individual handler function writes to it.  Since we "know" ~id~ will be the first result back, we take this opportunity to erase the buffer. This will surely be the cause of some bugs later.
 
    The ~done~ handler is a cheeky no-op.
+
+   Note that we're doing a pop-to-buffer then switch-to-buffer because I am a little hazy on how to pop up the window without hosing focus.
    
 #+begin_src emacs-lisp
 (defun e4l-live-object-handler (path arg)
@@ -211,9 +283,9 @@ E4L: [path: /live-object] ("(done)")
            (args (cdr item))
            (fn-name (intern-soft (concat "e4l--live-object-" (symbol-name type) "-handler")))
            (fn (if fn-name fn-name 'e4l--live-object-unfound-handler-handler)))
-      (funcall fn type args))
+      (funcall fn type args)))
+  (when (string-equal "done" arg)
     (pop-to-buffer "*e4l-object*")))
-
 
 (defun e4l--live-object-id-handler (type args)
   (erase-buffer)
@@ -223,7 +295,7 @@ E4L: [path: /live-object] ("(done)")
   (insert (format "%s\n" (car args))))
 
 (defun e4l--live-object-description-handler (type args)
-  (insert (string-join (mapcar #'symbol-name args) " "))
+  (insert (string-join (mapcar #'prin1-to-string args) " "))
   (insert "\n\n"))
 
 (defun e4l--live-object-unfound-handler-handler (type args)
@@ -234,9 +306,39 @@ E4L: [path: /live-object] ("(done)")
 
 (osc-server-set-handler e4l-osc-server "/live-object" #'e4l-live-object-handler)
 
+
 #+end_src
 
+#+RESULTS:
+| :generic | e4l-echo-handler | :handlers | ((/live-object . e4l-live-object-handler)) |
+
 Now anytime that s4m sends /live-object to us, we'll get a buffer full of information about the live object under inspection!
+
+
+* Documentation
+  s7 is self documenting, which means that we should use that facility to retrieve documentation about a given function.
+
+#+begin_src emacs-lisp 
+(defun e4l-doc-handler (path args)
+  (let ((docs (eval (read (concat "'" args)))))
+    (with-current-buffer (get-buffer-create "*e4l-doc*")
+      (erase-buffer)
+      (insert (pp docs)))))
+
+(osc-server-set-handler e4l-osc-server "/doc" #'e4l-doc-handler)
+#+end_src
+
+#+begin_src scheme 
+(define (e4l-send-documentation obj)
+  (send-to-e4l '/documentation
+               (object->string (list 
+                                :doc (documentation obj)          
+                                :sig (signature obj)              
+                                :arity (arity obj)))))
+
+(e4l-send-documentation string-append)
+#+end_src
+
 
 * Setting up a Minor Mode
 
@@ -246,22 +348,74 @@ Now anytime that s4m sends /live-object to us, we'll get a buffer full of inform
 
   (defvar e4l-mode-map
     (let ((map (make-sparse-keymap)))
-      (define-key map [remap eval-last-sexp] #'e4l-eval-last-sexp)
-      (define-key map [remap geiser-eval-buffer] #'e4l-eval-buffer))
+      (define-key map (kbd "C-x C-e") #'e4l-eval-last-sexp)
+      (define-key map (kbd "C-c C-b") #'e4l-send-buffer)
+      map)
     "Keymap for E4L mode")
 
   (define-minor-mode e4l-mode
     "Emacs for Live, a minor mode for interacting with Scheme for Max.
   Turning this minor mode on will enable keybindings, and open up the
-  UDP ports for communication."
+  UDP ports for communication.
+
+  If geiser-mode is enabled, this minor mode will disable it.  One day
+  e4l will just fit into geiser mode, but that is a long way off!"
     nil " λ🎛" e4l-mode-map
+    (if geiser-mode (geiser-mode -1))
     (run-e4l))
+
+
   #+end_src
 
-  For some reason the bindings don't work.  My guess is that the Geiser minor mode is taking precedence of the key-binding.  I'll need to look into this a little further.  My guess is that e4l-mode-map needs to inherit the geiser keymap.  It's been a long time since I have done some emacs coding, so I am not sure.
 
-  * Bad Network Mojo testing
+* A better console
+
+Console messages that end up using the emacs messaging system are ... well ... to put it bluntly, they suck.
+
+Instead lets dump them to a window to keep a running log.  We'll set up another osc handler and then grab the buffer and dump the contents to the end. 
+
+note that this code isn't quite up to snuff, but it is getting there.  Probably the best way to handle this is to send messages directly to a udpsend object. 
+
+#+begin_src emacs-lisp 
+(defun e4l-console-handler (path &rest args)
+  "Handles console messages and outputs them"
+  (with-current-buffer (get-buffer-create "*e4l-console*")
+    (goto-char (point-max))
+    (insert (format "%S" args) "\n")))
+
+(osc-server-set-handler e4l-osc-server "/console" #'e4l-console-handler)
+
+#+end_src
+
+* Magic Setup
+
+  
+
+* Better Errors
+
+This doesn't work, but it's a cool idea
+#+begin_src scheme 
+(set! (hook-functions *error-hook*)
+  (list (lambda (hook)
+          (send-to-e4l '/error (hook 'data)))))
+#+end_src
+* Bad Network Mojo testing
 
 For whatever reason I am having bad network mojo. The fix seems to be switching the receiving port of Max.  Some process, I expect maybe Max within Live, just chews up the port and refuses to spit it out.
 
 If this happens, the easiest thing to do is to switch ports from 7723 to some other number. You'll need to also update the udpreceive object, which I am sure is the culprit.
+
+#+begin_src emacs-lisp
+
+(defun e4l-change-port (port)
+  "Changes the e4l port to the new number and does an eval test to make sure it works."
+  (interactive "nPort Number: ")
+  (setq e4l-osc-clientport port)
+  (e4l-eval (concat "(apply send '(udp-send '/port-confirm "(number-to-string e4l-osc-clientport) "))")))
+
+(defun e4l-port-confirm-handler (path args)
+  (message "E4L: Confirmed port set to %s" args))
+ 
+(osc-server-set-handler e4l-osc-server "/port-confirm" #'e4l-port-confirm-handler)
+
+#+end_src


### PR DESCRIPTION
- immediately sets up a listening server on load.
- Started work on a documentation listener/handler
- A slightly better preamble that loads osc.  Assumes use-package.
- added an e4l-osc-clientport var so the port can be changed when max
  for live gets ahold of it and won't let go
- made run-e4l interactive
- extended the scheme-side emacs for live handler functions
- tweaked the emacs-side emacs for live handler
- console messages now go to a console buffer
- Sets up a port confirmation listener, and there is an interactive
  function to set the port